### PR TITLE
fix default options

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -51,13 +51,13 @@ export const defaultOptions: PostCSSPluginOptions = {
 };
 
 const postCSSPlugin = ({
-  plugins,
-  modules,
-  rootDir,
-  sassOptions,
-  lessOptions,
-  stylusOptions,
-  writeToFile
+  plugins = [],
+  modules = true,
+  rootDir = process.cwd(),
+  sassOptions = {},
+  lessOptions = {},
+  stylusOptions = {},
+  writeToFile = true
 }: PostCSSPluginOptions = defaultOptions): Plugin => ({
   name: "postcss2",
   setup(build) {


### PR DESCRIPTION
Fix the bug that if we pass `({plugins: [autoprefix]})` will make other options become undefined.