### PR TITLE
Support cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,3 +76,24 @@ To use preprocessors (`sass`, `scss`, `stylus`, `less`), just add the desired pr
 ```sh
 yarn add -D sass
 ```
+
+### Enable cache
+
+To reduce the rebuild time in dev mode, you can try to cache the CSS compilation result.
+
+> Note: currently it only supports `.css/.less/.scss`, doesn't support `.styl` yet.
+
+```js
+const esbuild = require("esbuild");
+const postCssPlugin = require("esbuild-plugin-postcss2");
+
+esbuild.build({
+  ...
+  plugins: [
+    postCssPlugin.default({
+      enableCache: true
+    })
+  ]
+  ...
+});
+```

--- a/src/index.ts
+++ b/src/index.ts
@@ -101,20 +101,6 @@ const postCSSPlugin = ({
         if (!sourceFullPath)
           sourceFullPath = path.resolve(args.resolveDir, args.path);
 
-        // hack
-        let exist = existsSync(sourceFullPath + ".js");
-        if (exist) {
-          return;
-        }
-        exist = existsSync(sourceFullPath);
-        if (!exist) {
-          sourceFullPath = path.resolve(
-            process.cwd(),
-            "node_modules",
-            args.path
-          );
-        }
-
         const sourceExt = path.extname(sourceFullPath);
         const sourceBaseName = path.basename(sourceFullPath, sourceExt);
         const isModule = sourceBaseName.match(/\.module$/);

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,8 +6,7 @@ import {
   readdirSync,
   statSync,
   stat,
-  writeFile,
-  existsSync
+  writeFile
 } from "fs-extra";
 import { TextDecoder } from "util";
 import {


### PR DESCRIPTION
## What did

- Support cache the `.css/.less/.scss` files compilation result (not support `.styl` yet, need help), to reduce the rebuild time in dev mode

## Background

I use this plugin to compile the less and less module CSS files with esbuild for my a little large project. It works fine in the production mode, but in the dev mode, when we modify a CSS file, it cost more than 4s to make a rebuild, even we enable the `incremental: true` option. It doesn't satisfy us.

After investigating, we found the pure js code only cost hundreds of milliseconds to rebuild, most of the rebuild time is cost by compiling CSS.

According to the [official advice](https://esbuild.github.io/plugins/#caching-your-plugin), we can add the cache strategy for the plugin. So I try it, and it works amazing, the rebuild time is reduced from more than **4s** to **600~700ms**.

## Result

In dev mode, enable incremental rebuild.

When `enableCache: false`, after changing a line of CSS code:

```
Build started
Build ended: 4660ms
Mapping /dashboard to "http://127.0.0.1:8888"
Serving "build" at http://127.0.0.1:8888
Ready for changes

Build started
...
CSS change detected build/diagnoseReport.css
CSS change detected build/dashboardApp.css
Change detected build/diagnoseReport.css.map
CSS change detected build/UserProfile-VBHKZLS6.css
Change detected build/UserProfile-VBHKZLS6.css.map
Change detected build/chunk-7CNVMG4T.js.map
Build ended: 4018ms
```

When `enableCache: true`, after changing a line of CSS code:

```
Build started
Build ended: 4564ms
Mapping /dashboard to "http://127.0.0.1:8888"
Serving "build" at http://127.0.0.1:8888
Ready for changes

Build started
...
Change detected build/chunk-ADLMHXCA.js
Change detected build/chunk-ADLMHXCA.js.map
Change detected build/chunk-DKAPZFJ6.js
Change detected build/chunk-DKAPZFJ6.js.map
Build ended: 699ms
```

