### PR TITLE
Fix resolve path error

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "esbuild-plugin-postcss2",
-  "version": "0.1.1",
+  "name": "@baurine/esbuild-plugin-postcss3",
+  "version": "0.2.1",
   "description": "Use postcss with esbuild",
   "repository": "https://github.com/martonlederer/esbuild-plugin-postcss2",
   "author": "Marton Lederer <marton@lederer.hu>",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@baurine/esbuild-plugin-postcss3",
-  "version": "0.2.1",
+  "name": "esbuild-plugin-postcss2",
+  "version": "0.1.1",
   "description": "Use postcss with esbuild",
   "repository": "https://github.com/martonlederer/esbuild-plugin-postcss2",
   "author": "Marton Lederer <marton@lederer.hu>",

--- a/package.json
+++ b/package.json
@@ -28,10 +28,12 @@
   "types": "src/modules.d.ts",
   "dependencies": {
     "autoprefixer": "^10.2.5",
+    "bulma": "^0.9.3",
     "fs-extra": "^9.1.0",
     "less": "^4.x",
     "postcss": "8.x",
     "postcss-modules": "^4.0.0",
+    "resolve": "^1.20.0",
     "resolve-file": "^0.3.0",
     "sass": "^1.x",
     "stylus": "^0.x",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "postcss": "8.x",
     "postcss-modules": "^4.0.0",
     "resolve": "^1.20.0",
-    "resolve-file": "^0.3.0",
     "sass": "^1.x",
     "stylus": "^0.x",
     "tmp": "^0.2.1"

--- a/src/index.ts
+++ b/src/index.ts
@@ -105,12 +105,9 @@ const postCSSPlugin = ({
         // Namespace is empty when using CSS as an entrypoint
         if (args.namespace !== "file" && args.namespace !== "") return;
 
-        // Resolve files from node_modules (ex: npm install normalize.css; npm install bulma)
         let sourceFullPath = resolve.sync(args.path, {
           basedir: args.resolveDir
         });
-        if (!sourceFullPath)
-          sourceFullPath = path.resolve(args.resolveDir, args.path);
 
         const sourceExt = path.extname(sourceFullPath);
         const sourceBaseName = path.basename(sourceFullPath, sourceExt);

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,7 +20,7 @@ import postcss from "postcss";
 import postcssModules from "postcss-modules";
 import less from "less";
 import stylus from "stylus";
-import resolveFile from "resolve-file";
+import resolve from "resolve";
 
 type StylusRenderOptions = Parameters<typeof stylus.render>[1]; // The Stylus.RenderOptions interface doesn't seem to be exported... So next best
 
@@ -105,8 +105,10 @@ const postCSSPlugin = ({
         // Namespace is empty when using CSS as an entrypoint
         if (args.namespace !== "file" && args.namespace !== "") return;
 
-        // Resolve files from node_modules (ex: npm install normalize.css)
-        let sourceFullPath = resolveFile(args.path);
+        // Resolve files from node_modules (ex: npm install normalize.css; npm install bulma)
+        let sourceFullPath = resolve.sync(args.path, {
+          basedir: args.resolveDir
+        });
         if (!sourceFullPath)
           sourceFullPath = path.resolve(args.resolveDir, args.path);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -57,7 +57,7 @@ export const defaultOptions: PostCSSPluginOptions = {
   lessOptions: {},
   stylusOptions: {},
   writeToFile: true
-}
+};
 
 const postCSSPlugin = ({
   plugins = [],

--- a/src/index.ts
+++ b/src/index.ts
@@ -57,7 +57,7 @@ export const defaultOptions: PostCSSPluginOptions = {
   lessOptions: {},
   stylusOptions: {},
   writeToFile: true
-};
+}
 
 const postCSSPlugin = ({
   plugins = [],

--- a/test/index.js
+++ b/test/index.js
@@ -6,6 +6,14 @@ const autoprefixer = require("autoprefixer"),
   fs = require("fs");
 
 describe("PostCSS esbuild tests", () => {
+  it("Works with empty options", (done) => {
+    testWithoutOptions(["tests/basic.ts"])
+      .then((res) => {
+        assert(res);
+        done();
+      })
+      .catch(done);
+  });
   it("Works with basic CSS imports", (done) => {
     test(["tests/basic.ts"])
       .then((res) => {
@@ -112,6 +120,15 @@ describe("PostCSS esbuild tests", () => {
       .catch(() => process.exit(1));
   });
 });
+
+function testWithoutOptions(entryPoint) {
+  return build({
+    entryPoints: entryPoint,
+    bundle: true,
+    outdir: "dist",
+    plugins: [postCSS.default()]
+  }).catch(() => process.exit(1));
+}
 
 function test(entryPoint) {
   return build({

--- a/test/index.js
+++ b/test/index.js
@@ -54,6 +54,14 @@ describe("PostCSS esbuild tests", () => {
       })
       .catch(done);
   });
+  it("Works with fake css file", (done) => {
+    test(["tests/BasePicker.js"])
+      .then((res) => {
+        assert(res);
+        done();
+      })
+      .catch(done);
+  });
   it("Works while waching css files directly", (done) => {
     let notTriggerTimeout = null;
     build({

--- a/test/tests/BasePicker.js
+++ b/test/tests/BasePicker.js
@@ -1,0 +1,4 @@
+// This usage comes from office-ui-fabric-react (renamed to fluent-ui later)
+// After installing office-ui-fabric-react
+// The below code exists in node_modules/office-ui-fabric-react/lib/components/pickers/BasePicker.js
+import * as stylesImport from "./BasePicker.scss";

--- a/test/tests/BasePicker.scss.js
+++ b/test/tests/BasePicker.scss.js
@@ -1,0 +1,36 @@
+// This file is copied from office-ui-fabric-react/lib/components/pickers/BasePicker.scss.js
+/* eslint-disable */
+// import { loadStyles } from '@microsoft/load-themed-styles';
+const loadStyles = () => {};
+loadStyles([
+  {
+    rawString:
+      ".pickerText_44202099{display:-webkit-box;display:-ms-flexbox;display:flex;-ms-flex-wrap:wrap;flex-wrap:wrap;-webkit-box-align:center;-ms-flex-align:center;align-items:center;-webkit-box-sizing:border-box;box-sizing:border-box;border:1px solid "
+  },
+  { theme: "neutralTertiary", defaultValue: "#a19f9d" },
+  {
+    rawString:
+      ";min-width:180px;min-height:30px}.pickerText_44202099:hover{border-color:"
+  },
+  { theme: "inputBorderHovered", defaultValue: "#323130" },
+  {
+    rawString:
+      "}.pickerText_44202099.inputFocused_44202099{position:relative;border-color:"
+  },
+  { theme: "inputFocusBorderAlt", defaultValue: "#0078d4" },
+  {
+    rawString:
+      "}.pickerText_44202099.inputFocused_44202099:after{pointer-events:none;content:'';position:absolute;left:-1px;top:-1px;bottom:-1px;right:-1px;border:2px solid "
+  },
+  { theme: "inputFocusBorderAlt", defaultValue: "#0078d4" },
+  {
+    rawString:
+      "}.pickerInput_44202099{height:34px;border:none;-webkit-box-flex:1;-ms-flex-positive:1;flex-grow:1;outline:0;padding:0 6px 0;-ms-flex-item-align:end;align-self:flex-end}.pickerItems_44202099{display:-webkit-box;display:-ms-flexbox;display:flex;-ms-flex-wrap:wrap;flex-wrap:wrap;max-width:100%}.screenReaderOnly_44202099{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);border:0}"
+  }
+]);
+export var pickerText = "pickerText_44202099";
+export var inputFocused = "inputFocused_44202099";
+export var pickerInput = "pickerInput_44202099";
+export var pickerItems = "pickerItems_44202099";
+export var screenReaderOnly = "screenReaderOnly_44202099";
+//# sourceMappingURL=BasePicker.scss.js.map

--- a/test/tests/node_modules.ts
+++ b/test/tests/node_modules.ts
@@ -1,1 +1,2 @@
 import "normalize.css";
+import "bulma/css/bulma.css";

--- a/yarn.lock
+++ b/yarn.lock
@@ -306,14 +306,6 @@ cssesc@^3.0.0:
   resolved "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz"
   integrity sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==
 
-cwd@^0.10.0:
-  version "0.10.0"
-  resolved "https://registry.npmjs.org/cwd/-/cwd-0.10.0.tgz"
-  integrity sha1-FyQAaUBXwioTsM8WFix+S3p/5Wc=
-  dependencies:
-    find-pkg "^0.1.2"
-    fs-exists-sync "^0.1.0"
-
 debug@4.3.1:
   version "4.3.1"
   resolved "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz"
@@ -407,48 +399,12 @@ execa@^0.8.0:
     signal-exit "^3.0.0"
     strip-eof "^1.0.0"
 
-expand-tilde@^1.2.2:
-  version "1.2.2"
-  resolved "https://registry.npmjs.org/expand-tilde/-/expand-tilde-1.2.2.tgz"
-  integrity sha1-C4HrqJflo9MdHD0QL48BRB5VlEk=
-  dependencies:
-    os-homedir "^1.0.1"
-
-expand-tilde@^2.0.2:
-  version "2.0.2"
-  resolved "https://registry.npmjs.org/expand-tilde/-/expand-tilde-2.0.2.tgz"
-  integrity sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=
-  dependencies:
-    homedir-polyfill "^1.0.1"
-
-extend-shallow@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz"
-  integrity sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=
-  dependencies:
-    is-extendable "^0.1.0"
-
 fill-range@^7.0.1:
   version "7.0.1"
   resolved "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz"
   integrity sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==
   dependencies:
     to-regex-range "^5.0.1"
-
-find-file-up@^0.1.2:
-  version "0.1.3"
-  resolved "https://registry.npmjs.org/find-file-up/-/find-file-up-0.1.3.tgz"
-  integrity sha1-z2gJG8+fMApA2kEbN9pczlovvqA=
-  dependencies:
-    fs-exists-sync "^0.1.0"
-    resolve-dir "^0.1.0"
-
-find-pkg@^0.1.2:
-  version "0.1.2"
-  resolved "https://registry.npmjs.org/find-pkg/-/find-pkg-0.1.2.tgz"
-  integrity sha1-G9wiwG42NlUy4qJIBGhUuXiNpVc=
-  dependencies:
-    find-file-up "^0.1.2"
 
 find-up@5.0.0:
   version "5.0.0"
@@ -467,11 +423,6 @@ fraction.js@^4.0.13:
   version "4.0.13"
   resolved "https://registry.npmjs.org/fraction.js/-/fraction.js-4.0.13.tgz"
   integrity sha512-E1fz2Xs9ltlUp+qbiyx9wmt2n9dRzPsS11Jtdb8D2o+cC7wr9xkkKsVKJuBX0ST+LVS+LhLO+SbLJNtfWcJvXA==
-
-fs-exists-sync@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.npmjs.org/fs-exists-sync/-/fs-exists-sync-0.1.0.tgz"
-  integrity sha1-mC1ok6+RjnLQjeyehnP/K1qNat0=
 
 fs-extra@^9.1.0:
   version "9.1.0"
@@ -539,24 +490,6 @@ glob@7.1.6, glob@^7.1.3, glob@^7.1.6:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-global-modules@^0.2.3:
-  version "0.2.3"
-  resolved "https://registry.npmjs.org/global-modules/-/global-modules-0.2.3.tgz"
-  integrity sha1-6lo77ULG1s6ZWk+KEmm12uIjgo0=
-  dependencies:
-    global-prefix "^0.1.4"
-    is-windows "^0.2.0"
-
-global-prefix@^0.1.4:
-  version "0.1.5"
-  resolved "https://registry.npmjs.org/global-prefix/-/global-prefix-0.1.5.tgz"
-  integrity sha1-jTvGuNo8qBEqFg2NSW/wRiv+948=
-  dependencies:
-    homedir-polyfill "^1.0.0"
-    ini "^1.3.4"
-    is-windows "^0.2.0"
-    which "^1.2.12"
-
 graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.2.0:
   version "4.2.6"
   resolved "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz"
@@ -583,13 +516,6 @@ he@1.2.0:
   version "1.2.0"
   resolved "https://registry.npmjs.org/he/-/he-1.2.0.tgz"
   integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
-
-homedir-polyfill@^1.0.0, homedir-polyfill@^1.0.1:
-  version "1.0.3"
-  resolved "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.3.tgz"
-  integrity sha512-eSmmWE5bZTK2Nou4g0AI3zZ9rswp7GRKoKXS1BLUkvPviOqs4YTN1djQIqrXy9k5gEtdLPy86JjRwsNM9tnDcA==
-  dependencies:
-    parse-passwd "^1.0.0"
 
 iconv-lite@^0.4.4:
   version "0.4.24"
@@ -631,22 +557,12 @@ inherits@2, inherits@^2.0.3:
   resolved "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
 
-ini@^1.3.4:
-  version "1.3.8"
-  resolved "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz"
-  integrity sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==
-
 is-binary-path@~2.1.0:
   version "2.1.0"
   resolved "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz"
   integrity sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==
   dependencies:
     binary-extensions "^2.0.0"
-
-is-buffer@^1.1.5:
-  version "1.1.6"
-  resolved "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz"
-  integrity sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==
 
 is-ci@^1.0.10:
   version "1.2.1"
@@ -661,11 +577,6 @@ is-core-module@^2.2.0:
   integrity sha512-XRAfAdyyY5F5cOXn7hYQDqh2Xmii+DEfIcQGxK/uNwMHhIkPWO0g8msXcbzLe+MpGoR951MlqM/2iIlU4vKDdQ==
   dependencies:
     has "^1.0.3"
-
-is-extendable@^0.1.0:
-  version "0.1.1"
-  resolved "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz"
-  integrity sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=
 
 is-extglob@^2.1.1:
   version "2.1.1"
@@ -709,11 +620,6 @@ is-what@^3.12.0:
   resolved "https://registry.npmjs.org/is-what/-/is-what-3.14.1.tgz"
   integrity sha512-sNxgpk9793nzSs7bA6JQJGeIuRBQhAaNGG77kzYQgMkrID+lS6SlK07K5LaptscDlSaIgH+GPFzf+d75FVxozA==
 
-is-windows@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.npmjs.org/is-windows/-/is-windows-0.2.0.tgz"
-  integrity sha1-3hqm1j6indJIc3tp8f+LgALSEIw=
-
 isexe@^2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz"
@@ -741,20 +647,6 @@ jsonfile@^6.0.1:
     universalify "^2.0.0"
   optionalDependencies:
     graceful-fs "^4.1.6"
-
-kind-of@^3.0.2:
-  version "3.2.2"
-  resolved "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz"
-  integrity sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=
-  dependencies:
-    is-buffer "^1.1.5"
-
-lazy-cache@^2.0.2:
-  version "2.0.2"
-  resolved "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz"
-  integrity sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=
-  dependencies:
-    set-getter "^0.1.0"
 
 less@^4.x:
   version "4.1.1"
@@ -938,11 +830,6 @@ once@^1.3.0:
   dependencies:
     wrappy "1"
 
-os-homedir@^1.0.1:
-  version "1.0.2"
-  resolved "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz"
-  integrity sha1-/7xJiDNuDoM94MFox+8VISGqf7M=
-
 p-finally@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz"
@@ -966,11 +853,6 @@ parse-node-version@^1.0.1:
   version "1.0.1"
   resolved "https://registry.npmjs.org/parse-node-version/-/parse-node-version-1.0.1.tgz"
   integrity sha512-3YHlOa/JgH6Mnpr05jP9eDG254US9ek25LyIxZlDItp2iJtwyaXQb57lBYLdT3MowkUFYEV2XXNAYIPlESvJlA==
-
-parse-passwd@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz"
-  integrity sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY=
 
 path-exists@^4.0.0:
   version "4.0.0"
@@ -1133,41 +1015,12 @@ require-directory@^2.1.1:
   resolved "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz"
   integrity sha1-jGStX9MNqxyXbiNE/+f3kqam30I=
 
-resolve-dir@^0.1.0:
-  version "0.1.1"
-  resolved "https://registry.npmjs.org/resolve-dir/-/resolve-dir-0.1.1.tgz"
-  integrity sha1-shklmlYC+sXFxJatiUpujMQwJh4=
-  dependencies:
-    expand-tilde "^1.2.2"
-    global-modules "^0.2.3"
-
-resolve-file@^0.3.0:
-  version "0.3.0"
-  resolved "https://registry.npmjs.org/resolve-file/-/resolve-file-0.3.0.tgz"
-  integrity sha1-EeH7RkVm06fFAMt+lIHo8LAKFO8=
-  dependencies:
-    cwd "^0.10.0"
-    expand-tilde "^2.0.2"
-    extend-shallow "^2.0.1"
-    fs-exists-sync "^0.1.0"
-    homedir-polyfill "^1.0.1"
-    lazy-cache "^2.0.2"
-    resolve "^1.2.0"
-
 resolve-url@^0.2.1:
   version "0.2.1"
   resolved "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz"
   integrity sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=
 
-resolve@^1.1.7, resolve@^1.2.0:
-  version "1.20.0"
-  resolved "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz"
-  integrity sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==
-  dependencies:
-    is-core-module "^2.2.0"
-    path-parse "^1.0.6"
-
-resolve@^1.20.0:
+resolve@^1.1.7, resolve@^1.20.0:
   version "1.20.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.20.0.tgz#629a013fb3f70755d6f0b7935cc1c2c5378b1975"
   integrity sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==
@@ -1220,13 +1073,6 @@ serialize-javascript@5.0.1:
   integrity sha512-SaaNal9imEO737H2c05Og0/8LUXG7EnsZyMa8MzkmuHoELfT6txuj0cMqRj6zfPKnmQ1yasR4PCJc8x+M4JSPA==
   dependencies:
     randombytes "^2.1.0"
-
-set-getter@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.npmjs.org/set-getter/-/set-getter-0.1.0.tgz"
-  integrity sha1-12nBgsnVpR9AkUXy+6guXoboA3Y=
-  dependencies:
-    to-object-path "^0.3.0"
 
 shebang-command@^1.2.0:
   version "1.2.0"
@@ -1369,13 +1215,6 @@ tmp@^0.2.1:
   dependencies:
     rimraf "^3.0.0"
 
-to-object-path@^0.3.0:
-  version "0.3.0"
-  resolved "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz"
-  integrity sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=
-  dependencies:
-    kind-of "^3.0.2"
-
 to-regex-range@^5.0.1:
   version "5.0.1"
   resolved "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz"
@@ -1425,7 +1264,7 @@ which@2.0.2, which@^2.0.1:
   dependencies:
     isexe "^2.0.0"
 
-which@^1.2.12, which@^1.2.9:
+which@^1.2.9:
   version "1.3.1"
   resolved "https://registry.npmjs.org/which/-/which-1.3.1.tgz"
   integrity sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==

--- a/yarn.lock
+++ b/yarn.lock
@@ -161,6 +161,11 @@ browserslist@^4.16.3:
     escalade "^3.1.1"
     node-releases "^1.1.70"
 
+bulma@^0.9.3:
+  version "0.9.3"
+  resolved "https://registry.yarnpkg.com/bulma/-/bulma-0.9.3.tgz#ddccb7436ebe3e21bf47afe01d3c43a296b70243"
+  integrity sha512-0d7GNW1PY4ud8TWxdNcP6Cc8Bu7MxcntD/RRLGWuiw/s0a9P+XlH/6QoOIrmbj6o8WWJzJYhytiu9nFjTszk1g==
+
 camelcase@^6.0.0:
   version "6.2.0"
   resolved "https://registry.npmjs.org/camelcase/-/camelcase-6.2.0.tgz"
@@ -1157,6 +1162,14 @@ resolve-url@^0.2.1:
 resolve@^1.1.7, resolve@^1.2.0:
   version "1.20.0"
   resolved "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz"
+  integrity sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==
+  dependencies:
+    is-core-module "^2.2.0"
+    path-parse "^1.0.6"
+
+resolve@^1.20.0:
+  version "1.20.0"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.20.0.tgz#629a013fb3f70755d6f0b7935cc1c2c5378b1975"
   integrity sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==
   dependencies:
     is-core-module "^2.2.0"


### PR DESCRIPTION
Use [resolve](https://www.npmjs.com/package/resolve) npm package instead of [resolve-file](https://www.npmjs.com/package/resolve-files) npm package to resolve the import path, this can fix the 2 below bugs:

- https://github.com/martonlederer/esbuild-plugin-postcss2/issues/27
- https://github.com/evanw/esbuild/issues/1834

The root reason I have reported to resolve-file repo in https://github.com/doowb/resolve-file/issues/2#issuecomment-985319132